### PR TITLE
Link verification option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ for pdf in pdfs[:5]:
 
 To prevent the search for attachments with format verification, set `verif=False`, which is `True` by default.
 
-Format verification is presented here: #4
+Format verification is presented here: https://github.com/iTeam-S/WebSearch/pull/4 
 
 ```python
 from websearch import WebSearch

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 pip3 install websearch-python
 ```
 
-## Use
+## Usage
 
 ### Quick Start
 
@@ -98,6 +98,15 @@ for pdf in pdfs[:5]:
    https://www.jjc.edu/sites/default/files/Academics/Math/M220%20Master%20Syllabus%20SP18.pdf
    https://www.sonoma.edu/sites/www/files/2018-19cat-11math.pdf
    https://www.svsd.net/cms/lib5/PA01001234/Centricity/Domain/1009/3.3-3.3B-Practice-KEY.pdf
+```
+
+To prevent the search for attachments with format verification, set `verif=False`, which is `True` by default.
+
+Format verification is presented here: #4
+
+```python
+from websearch import WebSearch
+web = WebSearch('Math 220', verif=False)
 ```
 
 

--- a/websearch/script.py
+++ b/websearch/script.py
@@ -8,15 +8,27 @@ class WebSearch :
     '''
     _headers =  {'User-Agent': 'Googlebot/2.1 (http://www.googlebot.com/bot.html)'}
 
-    def __init__(self, query) :
+    def __init__(self, query, verif=True):
+        '''
+            query: prend l'expression à rechercher.
+            verif: si True, lance une requete à l'url pour valider
+                le bon format du résultat, pardefaut à True.
+            peut être desactiver en mettant `verif=False` en argument.
+        '''
         self.query = query
+        self.verif = verif
         # utiliser pour l'optimisation
         self.__data = {}
 
-    def __verif_content(self, urls, doc):
+    def __verif_content(self, urls, ext):
         '''
             Verification du bon format du lien
         '''
+        if not self.verif:
+            # si Faux pas de verification
+            # reenvoie directement la liste données
+            return urls
+        
         new_urls = []
         for url in urls:
             # Envoie d'une requete qui recupere que l'en tête.
@@ -26,7 +38,7 @@ class WebSearch :
                 print(err)
                 continue
             # Verfier si le lien renvoie bien le format voulu.
-            if rq.get('content-type') == f'application/{doc}':
+            if rq.get('content-type') == f'application/{ext}':
                 new_urls.append(url)
         # renvoyer les urls verfiés.
         return new_urls
@@ -153,9 +165,4 @@ class WebSearch :
          #  Sauvegarde des resultats pour optimiser la prochaine même appel.
         self.__data['pptx'] = (self.query, result)
         return result
-
-
-
-
-    
 


### PR DESCRIPTION
For each link obtained after research, a check is made for each link to ensure that the link obtained is a direct link from the attachment of the format in question.
However, an option to prevent the execution of this functionality has been implemented, because the execution time will be impacted since the code must make a one-to-one request for these links.

the added option is to put a `verif = False` at the initialization of the search.

```python
from websearch import WebSearch
web = WebSearch('Math 220', verif=False)
```